### PR TITLE
add a gitignore file to hide chipmunk compile artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+vendor/Chipmunk-4.1.0/ruby/Makefile
+vendor/Chipmunk-4.1.0/ruby/chipmunk.bundle
+vendor/Chipmunk-4.1.0/ruby/*.o
+


### PR DESCRIPTION
noticed that these files were cluttering up my git status after compiling chipmunk.  they should be ignored.
