### PR TITLE
Replace ruby-opengl with opengl for modern ruby/OSX/*nix support

### DIFF
--- a/README
+++ b/README
@@ -26,26 +26,26 @@ Running:
 
 Versions tested:
   rubygems    0.9.4
-  ruby-opengl 0.40.1
+  opengl      0.7.0.pre1
   net-ssh     1.1.2
 
 Installation instructions (Ubuntu/Debian):
   sudo apt-get install rubygems rake ruby1.8-dev libgl1-mesa-dev libglu1-mesa-dev libglut3-dev build-essential
-  sudo gem install net-ssh ruby-opengl -r
+  sudo gem install net-ssh opengl --pre -r
 
 Installation instructions (Mandriva/RedHat):
   sudo urpmi ruby ruby-devel ruby-RubyGems ruby-rake
   sudo urpmi libmesagl1-devel libmesaglut3-devel ruby-rbogl
-  sudo gem install net-ssh ruby-opengl -r
+  sudo gem install net-ssh opengl --pre -r
 
 Installation instructions (Mac OS/X):
   <install ruby & rubygems>
-  sudo gem install net-ssh ruby-opengl file-tail -r
+  sudo gem install net-ssh opengl --pre file-tail -r
 
 Installation instructions (Windows):
   One-click Ruby installer from http://rubyforge.org/projects/rubyinstaller/
   Start RubyGems/RubyGems Package Manager
-  gem install net-ssh ruby-opengl
+  gem install net-ssh opengl --pre
 
   (Make sure you've got accelerated OpenGL installed for your graphics card. Some drivers
   shipped with your version of Windows do not include this, and it can be installed by

--- a/README.txt
+++ b/README.txt
@@ -29,7 +29,7 @@ Real-time view of server traffic and events using OpenGL and SSH.
 
 == REQUIREMENTS:
 * rubygems    0.9.4
-* ruby-opengl 0.40.1
+* opengl      0.7.0.pre1
 * net-ssh     1.1.2
 * opengl/ruby development packages (ruby1.8-dev libgl1-mesa-dev libglu1-mesa-dev libglut3-dev)
 

--- a/Rakefile
+++ b/Rakefile
@@ -10,10 +10,11 @@ Hoe.new('gltail', GlTail::VERSION) do |p|
   p.email = 'mr@fudgie.org'
   p.summary = 'View real-time data and statistics from any logfile on any server with SSH, in an intuitive and entertaining way.'
   p.description = p.paragraphs_of('README.txt', 2..5).join("\n\n")
-  p.url = p.paragraphs_of('README.txt', 0).first.split(/\n/)[1..-1]
+  #p.url = p.paragraphs_of('README.txt', 0).first.split(/\n/)[1..-1]
+  p.url = 'http://www.fudgie.org'
   p.changes = p.paragraphs_of('History.txt', 0..1).join("\n\n")
-  p.extra_deps << ['ruby-opengl', '>= 0.40.1']
-  p.extra_deps << ['net-ssh', '<= 1.1.4']
+  p.extra_deps << ['opengl', '~> 0.7.0.pre1']
+  p.extra_deps << ['net-ssh', '>= 1.1.4']
 end
 
 # vim: syntax=Ruby

--- a/lib/gl_tail.rb
+++ b/lib/gl_tail.rb
@@ -5,7 +5,7 @@
 #
 
 module GlTail
-  VERSION = '0.1.8'
+  VERSION = '0.1.9'
 end
 
 begin
@@ -18,22 +18,22 @@ end
 gem_version = Gem::RubyGemsVersion.split('.')
 
 if gem_version[0].to_i == 0 && gem_version[1].to_i < 9 || (gem_version[0].to_i == 0 && gem_version[1].to_i >= 9 && gem_version[2].to_i < 2)
-  puts "rubygems too old to build ruby-opengl. Please update."
+  puts "rubygems too old to build opengl. Please update."
   puts "Ubuntu:"
   puts "  sudo gem update --system"
   exit
 end
 
 begin
-  gem 'ruby-opengl', '>= 0.40.1'
+  gem 'opengl', '~> 0.7.0.pre1'
   require 'gl'
   require 'glut'
 rescue LoadError
-  puts "Missing or outdated gem: ruby-opengl (>=0.40.1)"
+  puts "Missing or outdated gem: opengl (~> 0.7.0.pre1)"
   puts "Ubuntu:"
   puts "  sudo apt-get install rake ruby1.8-dev libgl1-mesa-dev libglu1-mesa-dev libglut3-dev"
-  puts "  sudo gem install -y ruby-opengl -r"
-  puts "\nFor more information: http://ruby-opengl.rubyforge.org/build_install.html"
+  puts "  sudo gem install -y opengl --pre -r"
+  puts "\nFor more information: http://rubygems.org/gems/opengl"
   exit
 end
 

--- a/lib/gl_tail/element.rb
+++ b/lib/gl_tail/element.rb
@@ -252,7 +252,7 @@ class Element
       text = sprintf("%#{@block_width}s", @name.length > @block_width ? @name[-@block_width..-1] : @name)
 
       if text != @last_text
-        glDeleteLists(@text_list,1)
+        glDeleteLists(@text_list,1) unless @text_list.nil?
         @text_list = nil
       end 
      
@@ -275,7 +275,7 @@ class Element
       txt = txt[1..-1]
       text = @name[0..@block_width-1]
       if text != @last_text
-        glDeleteLists(@text_list,1)
+        glDeleteLists(@text_list,1) unless @text_list.nil?
         @text_list = nil
       end 
 


### PR DESCRIPTION
Switched from ruby-opengl to opengl so that we can work with modern versions of ruby on modern versions of OSX/*nix http://rubyforge.org/tracker/index.php?func=detail&aid=29477&group_id=2103&atid=8185
