### PR TITLE
Update to opengl 0.9, add mingw support

### DIFF
--- a/bin/gl_tail
+++ b/bin/gl_tail
@@ -94,7 +94,7 @@ end
 
 ######## TRAP Interrupts and exit cleanly ########
 
-if RUBY_PLATFORM.split('-',2).last != "mswin32"
+unless Gem.win_platform?
 	trap("HUP") { exit }
 	trap("INT") { exit }
 	trap("QUIT") { exit }

--- a/gltail.gemspec
+++ b/gltail.gemspec
@@ -20,7 +20,9 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency('opengl', '~> 0.8.0')
+  gem.add_dependency('opengl', '~> 0.9.0')
+  gem.add_dependency('glu')
+  gem.add_dependency('glut')
   gem.add_dependency('net-ssh', '>= 1.1.4')
   gem.add_dependency('net-ssh-gateway')
   gem.add_dependency('chipmunk')

--- a/lib/gl_tail/engine.rb
+++ b/lib/gl_tail/engine.rb
@@ -312,7 +312,7 @@ module GlTail
         @space.damping = 0.89
         @space.gravity = CP::Vec2.new(0, -85)
         @space.iterations = 2
-        @space.elastic_iterations = 0
+        #@space.elastic_iterations = 0
       end 
     end
 


### PR DESCRIPTION
Both of these commits were necessary for the gem to work on mingw ruby + devkit. I think opengl 0.9 also has binary packages, which 0.8 did not (?), which also eases installation.